### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ The agent will expose a Web UI and an API that will allow you do things like:
 * Look for all the prefixes that traverses or originates in a particular ASN.
 * Check all the prefixes in the router that allows you to reach certain prefixes or IP.
 
-You can read the full list of features in the following [link](http://sdn-internet-router-sir.readthedocs.org/en/latest/features/index.html).
+You can read the full list of features in the following [link](https://sdn-internet-router-sir.readthedocs.io/en/latest/features/index.html).
 
 Applications
 ============
 
-This agent will give you some visibility about your network. You can use this data to better choose your network equipment, to do traffic engineering, capacity planning, peering decisions... anything you want. You can see some use cases in the following [link](http://sdn-internet-router-sir.readthedocs.org/en/latest/use_cases/index.html).
+This agent will give you some visibility about your network. You can use this data to better choose your network equipment, to do traffic engineering, capacity planning, peering decisions... anything you want. You can see some use cases in the following [link](https://sdn-internet-router-sir.readthedocs.io/en/latest/use_cases/index.html).
 
 Here is a list of links where you can get tools and apps that leverages on SIR:
 
@@ -34,6 +34,6 @@ Here is a list of links where you can get tools and apps that leverages on SIR:
 Documentation
 =============
 
-You can find the documentation on [Read the Docs](http://sdn-internet-router-sir.readthedocs.org/en/latest/).
+You can find the documentation on [Read the Docs](https://sdn-internet-router-sir.readthedocs.io/en/latest/).
 
 If you have any questions or you want to chat about SIR feel free to join the ``SIR`` channel on slack at [network.toCode()](https://networktocode.herokuapp.com/).

--- a/docs/how_to_eos/manual_deploy.rst
+++ b/docs/how_to_eos/manual_deploy.rst
@@ -29,8 +29,8 @@ First you have to get all the related configuration files and copy them to the c
     Arista Networks EOS shell
 
     [dbarroso@lab ~]$ cd /tmp/
-    [dbarroso@lab tmp]$ sudo ip netns exec ns-mgmtVRF wget http://sdn-internet-router-sir.readthedocs.org/en/latest/_static/eos_files.tar.gz
-    --2015-07-28 13:30:35--  http://sdn-internet-router-sir.readthedocs.org/en/latest/_static/eos_files.tar.gz
+    [dbarroso@lab tmp]$ sudo ip netns exec ns-mgmtVRF wget https://sdn-internet-router-sir.readthedocs.io/en/latest/_static/eos_files.tar.gz
+    --2015-07-28 13:30:35--  https://sdn-internet-router-sir.readthedocs.io/en/latest/_static/eos_files.tar.gz
     Resolving sdn-internet-router-sir.readthedocs.org... 162.209.114.75
     Connecting to sdn-internet-router-sir.readthedocs.org|162.209.114.75|:80... connected.
     HTTP request sent, awaiting response... 200 OK

--- a/scripts/deploy_sir_eos.sh
+++ b/scripts/deploy_sir_eos.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-PMACCT_URL="http://sdn-internet-router-sir.readthedocs.org/en/latest/_static/eos_files.tar.gz"
+PMACCT_URL="https://sdn-internet-router-sir.readthedocs.io/en/latest/_static/eos_files.tar.gz"
 TMP_FOLDER="/tmp"
 PMACCT_FOLDER="/tmp/eos_files"
 

--- a/sir/templates/includes/header.html
+++ b/sir/templates/includes/header.html
@@ -14,6 +14,6 @@
   <a href='{{ url_for('start_page')}}'>HOME</a> |
   <a href='{{ url_for('analytics_view_help')}}'>ANALYTICS</a> |
   <a href='{{ url_for('browse_view_variables')}}'>VARIABLES</a> |
-  <a href='http://sdn-internet-router-sir.readthedocs.org/' target="_blank">DOCUMENTATION</a>
+  <a href='https://sdn-internet-router-sir.readthedocs.io/' target="_blank">DOCUMENTATION</a>
 </nav>
 <div class="page">


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
